### PR TITLE
Add option to sort workspaces by their position when using -a

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Usage: i3-easyfocus <options>
  -a --all               label visible windows on all outputs
  -c --current           label visible windows within current container
  -r --rapid             rapid mode, keep on running until Escape is pressed
+ -s --sort-by <method>  how to sort the workspaces' labels when using --all:
+                            - <location> based on their location (default)
+                            - <num> using the workspaces' numbers
  -f --font <font-name>  set font name, see `xlsfonts` for available fonts
 ```
 

--- a/src/ipc.h
+++ b/src/ipc.h
@@ -9,8 +9,13 @@ typedef enum {
     CURRENT_CONTAINER
 } SearchArea;
 
+typedef enum {
+    BY_LOCATION,
+    BY_NUMBER
+} SortMethod;
+
 int ipc_init();
-Window *ipc_visible_windows(SearchArea search_area);
+Window *ipc_visible_windows(SearchArea search_area, SortMethod sort_method);
 int ipc_focus_window(Window *window);
 void ipc_finish();
 


### PR DESCRIPTION
Using `--sort-by <method>` here could be a bit weird since the other boolean arguments (-a, -c, -i, -w) are not parsed with strings. What do you think?

We could also add a flag to prioritize the 'primary' output.