### PR TITLE
Add -k/--key for avy vs alpha key maps

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -2,7 +2,8 @@
 #define I3_EASYFOCUS_CONFIG
 
 #define EXIT_KEYSYM XK_Escape
-#define LABEL_KEYSYMS { XK_a, XK_b, XK_c, XK_d, XK_e, XK_f, XK_g, XK_h, XK_i, XK_j, XK_k, XK_l, XK_m, XK_n, XK_o, XK_p, XK_q, XK_r, XK_s, XK_t, XK_u, XK_v, XK_w, XK_x, XK_y, XK_z, XK_1, XK_2, XK_3, XK_4, XK_5, XK_6, XK_7, XK_8, XK_9, XK_0 }
+#define LABEL_KEYSYMS_AVY { XK_a, XK_s, XK_d, XK_f, XK_g, XK_h, XK_j, XK_k, XK_l, XK_q, XK_w, XK_e, XK_r, XK_t, XK_y, XK_u, XK_i, XK_o, XK_p, XK_z, XK_x, XK_c, XK_v, XK_b, XK_n, XK_m, XK_1, XK_2, XK_3, XK_4, XK_5, XK_6, XK_7, XK_8, XK_9, XK_0 }
+#define LABEL_KEYSYMS_ALPHA { XK_a, XK_b, XK_c, XK_d, XK_e, XK_f, XK_g, XK_h, XK_i, XK_j, XK_k, XK_l, XK_m, XK_n, XK_o, XK_p, XK_q, XK_r, XK_s, XK_t, XK_u, XK_v, XK_w, XK_x, XK_y, XK_z, XK_1, XK_2, XK_3, XK_4, XK_5, XK_6, XK_7, XK_8, XK_9, XK_0 }
 
 #define XCB_DEFAULT_FONT_NAME "-Misc-Fixed-Bold-R-Normal--18-120-100-100-C-90-ISO10646-1"
 

--- a/src/i3-easyfocus.c
+++ b/src/i3-easyfocus.c
@@ -243,7 +243,7 @@ static int select_window()
 
         if (create_window_labels(win))
         {
-            map_deinit();
+            map_free();
             window_free(win);
             return 1;
         }
@@ -262,7 +262,7 @@ static int select_window()
             {
                 if (handle_selection(selection))
                 {
-                    map_deinit();
+                    map_free();
                     window_free(win);
                     return 1;
                 }
@@ -271,7 +271,7 @@ static int select_window()
             }
         }
 
-        map_deinit();
+        map_free();
         window_free(win);
     }
 

--- a/src/i3-easyfocus.c
+++ b/src/i3-easyfocus.c
@@ -82,21 +82,21 @@ static void parse_args(int argc, char *argv[])
             font_name = strdup(optarg);
             break;
         case 'k':
-	        if (strcmp(optarg, "avy") == 0)
-		    {
-			    key_mode = LABEL_KEY_MODE_AVY;
-		    }
-	        else if (strcmp(optarg, "alpha") == 0)
-		    {
-			    key_mode = LABEL_KEY_MODE_ALPHA;
-		    }
-	        else
-		    {
-			    fprintf(stderr, "unrecognized key style type: %s\n", optarg);
-			    print_help();
-			    exit(EXIT_FAILURE);
-		    }
-	        break;
+            if (strcmp(optarg, "avy") == 0)
+            {
+                key_mode = LABEL_KEY_MODE_AVY;
+            }
+            else if (strcmp(optarg, "alpha") == 0)
+            {
+                key_mode = LABEL_KEY_MODE_ALPHA;
+            }
+            else
+            {
+                fprintf(stderr, "unrecognized key style type: %s\n", optarg);
+                print_help();
+                exit(EXIT_FAILURE);
+            }
+            break;
         case 's':
             got_sort_method = true;
             if (strcmp(optarg, "num") == 0)
@@ -243,7 +243,7 @@ static int select_window()
 
         if (create_window_labels(win))
         {
-	        map_deinit();
+            map_deinit();
             window_free(win);
             return 1;
         }
@@ -262,7 +262,7 @@ static int select_window()
             {
                 if (handle_selection(selection))
                 {
-	                map_deinit();
+                    map_deinit();
                     window_free(win);
                     return 1;
                 }

--- a/src/map.c
+++ b/src/map.c
@@ -23,16 +23,16 @@ void map_init(label_key_mode_e mode)
     current = 0;
 
     switch(mode)
-	{
-	case LABEL_KEY_MODE_AVY:
-		label_keysyms = label_avy_keysyms;
-		map_length = LENGTH_AVY;
-		break;
-	case LABEL_KEY_MODE_ALPHA:
-		label_keysyms = label_alpha_keysyms;
-		map_length = LENGTH_ALPHA;
-		break;
-	}
+    {
+    case LABEL_KEY_MODE_AVY:
+        label_keysyms = label_avy_keysyms;
+        map_length = LENGTH_AVY;
+        break;
+    case LABEL_KEY_MODE_ALPHA:
+        label_keysyms = label_alpha_keysyms;
+        map_length = LENGTH_ALPHA;
+        break;
+    }
     win_map = calloc(map_length, sizeof(Window*));
 }
 
@@ -67,8 +67,8 @@ Window *map_get(xcb_keysym_t keysym)
 
 void map_deinit()
 {
-	free(win_map);
-	win_map = NULL;
-	map_length = 0;
-	current = 0;
+    free(win_map);
+    win_map = NULL;
+    map_length = 0;
+    current = 0;
 }

--- a/src/map.c
+++ b/src/map.c
@@ -4,23 +4,43 @@
 
 #include <X11/keysym.h>
 #include <X11/keysymdef.h>
+#include <stdlib.h>
 
-#define LENGTH (sizeof(label_keysyms) / sizeof(label_keysyms[0]))
-static xcb_keysym_t label_keysyms[] = LABEL_KEYSYMS;
+#define LENGTH_AVY (sizeof(label_avy_keysyms) / sizeof(label_avy_keysyms[0]))
+static xcb_keysym_t label_avy_keysyms[] = LABEL_KEYSYMS_AVY;
 
-static Window *win_map[LENGTH];
+#define LENGTH_ALPHA (sizeof(label_alpha_keysyms) / sizeof(label_alpha_keysyms[0]))
+static xcb_keysym_t label_alpha_keysyms[] = LABEL_KEYSYMS_ALPHA;
+
+static xcb_keysym_t *label_keysyms = NULL;
+
+static Window **win_map = NULL;
+static size_t map_length = 0;
 static size_t current = 0;
 
-void map_init()
+void map_init(label_key_mode_e mode)
 {
     current = 0;
+
+    switch(mode)
+	{
+	case LABEL_KEY_MODE_AVY:
+		label_keysyms = label_avy_keysyms;
+		map_length = LENGTH_AVY;
+		break;
+	case LABEL_KEY_MODE_ALPHA:
+		label_keysyms = label_alpha_keysyms;
+		map_length = LENGTH_ALPHA;
+		break;
+	}
+    win_map = calloc(map_length, sizeof(Window*));
 }
 
 xcb_keysym_t map_add(Window *win)
 {
-    if (current >= LENGTH)
+    if (current >= map_length)
     {
-        LOG("too many windows, only configured %lu keysyms\n", LENGTH);
+        LOG("too many windows, only configured %lu keysyms\n", map_length);
         return XCB_NO_SYMBOL;
     }
 
@@ -33,7 +53,7 @@ xcb_keysym_t map_add(Window *win)
 Window *map_get(xcb_keysym_t keysym)
 {
     size_t i;
-    for (i = 0; i < LENGTH; i++)
+    for (i = 0; i < map_length && i < current; i++)
     {
         if (label_keysyms[i] == keysym)
         {
@@ -43,4 +63,12 @@ Window *map_get(xcb_keysym_t keysym)
 
     LOG("selection not in range\n");
     return NULL;
+}
+
+void map_deinit()
+{
+	free(win_map);
+	win_map = NULL;
+	map_length = 0;
+	current = 0;
 }

--- a/src/map.c
+++ b/src/map.c
@@ -65,7 +65,7 @@ Window *map_get(xcb_keysym_t keysym)
     return NULL;
 }
 
-void map_deinit()
+void map_free()
 {
     free(win_map);
     win_map = NULL;

--- a/src/map.h
+++ b/src/map.h
@@ -10,13 +10,11 @@ typedef enum
     LABEL_KEY_MODE_ALPHA,
 
     LABEL_KEY_MODE_DEFAULT = LABEL_KEY_MODE_AVY,
-    
-    LABEL_KEY_MODE_MAX,
 } label_key_mode_e;
 
 void map_init(label_key_mode_e mode);
 xcb_keysym_t map_add(Window *win);
 Window *map_get(xcb_keysym_t keysym);
-void map_deinit();
+void map_free();
 
 #endif

--- a/src/map.h
+++ b/src/map.h
@@ -4,8 +4,19 @@
 #include <xcb/xcb.h>
 #include "win.h"
 
-void map_init();
+typedef enum
+{
+	LABEL_KEY_MODE_AVY,
+	LABEL_KEY_MODE_ALPHA,
+
+	LABEL_KEY_MODE_DEFAULT = LABEL_KEY_MODE_AVY,
+	
+	LABEL_KEY_MODE_MAX,
+} label_key_mode_e;
+
+void map_init(label_key_mode_e mode);
 xcb_keysym_t map_add(Window *win);
 Window *map_get(xcb_keysym_t keysym);
+void map_deinit();
 
 #endif

--- a/src/map.h
+++ b/src/map.h
@@ -6,12 +6,12 @@
 
 typedef enum
 {
-	LABEL_KEY_MODE_AVY,
-	LABEL_KEY_MODE_ALPHA,
+    LABEL_KEY_MODE_AVY,
+    LABEL_KEY_MODE_ALPHA,
 
-	LABEL_KEY_MODE_DEFAULT = LABEL_KEY_MODE_AVY,
-	
-	LABEL_KEY_MODE_MAX,
+    LABEL_KEY_MODE_DEFAULT = LABEL_KEY_MODE_AVY,
+    
+    LABEL_KEY_MODE_MAX,
 } label_key_mode_e;
 
 void map_init(label_key_mode_e mode);


### PR DESCRIPTION
Define the maps and update to support command-line map selection.  Default is now avy-style (home row).

Make the key maps dynamic with the window list dynamically allocated based on size of the keymap selected.
Add a map_deinit() to clean up allocated memory.

/closes #8 #5 