### PR TITLE
[WIP] Try containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,16 @@
+FROM debian
+
+RUN apt-get update -y
+
+RUN apt-get install -y autoconf xcb-proto libxcb-keysyms1-dev glibc-source libjson-glib-dev gtk-doc-tools gobject-introspection libtool libx11-dev git
+
+RUN git clone https://github.com/altdesktop/i3ipc-glib/ \
+    && cd i3ipc-glib \
+    && ./autogen.sh \
+    && make \
+    && make install
+
+RUN git clone https://github.com/cornerman/i3-easyfocus \
+    && cd i3-easyfocus \
+    && make \
+    && mv i3-easyfocus /usr/local/bin


### PR DESCRIPTION
Since I always find it hell to install all build dependencies on a host machine -> Try container.

Can be built and run with:
```
> podman run -it --rm --ipc=host $(podman build -q -f Containerfile .)                                                                                                                                                             
root@3cad866455fb:/# i3-easyfocus
i3-easyfocus: error while loading shared libraries: libi3ipc-glib-1.0.so.0: cannot open shared object file: No such file or directory
```

(`alias podman=docker` possible if you use Docker).

Any idea why it can't find the shared library?